### PR TITLE
let in 式を追加した

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -45,13 +45,14 @@ digit = zero | non_zero_digit
 integer = ["+" | "-"], (zero | (non_zero_digit, { digit }))
 letter = "a" | "b" | "c" | ... | "z" | "A" | "B" | "C" | ... | "Z"
 identifier = letter, { letter | digit }
-factor = integer | symbol | if_expr | ("(", logical_expr_or, ")")
+factor = integer | identifier | if_expr | ("(", logical_expr_or, ")") | let_expr
 term = factor, { ("*" | "/"), factor }
 arithmetic_expr = term, { ("+" | "-"), term }
 comparison_expr = arithmetic_expr, { ("==" | "!=" | "<" | "<=" | "=>" | ">"), arithmetic_expr }
 logical_expr_and = comparison_expr, { "&&", comparison_expr }
 logical_expr_or = logical_expr_and, { "||", logical_expr_and }
 if_expr = "if", logical_expr_or, "then", logical_expr_or, "else", logical_expr_or
+let_expr = "let", identifier, "=", logical_expr_or, "in", logical_expr_or
 statement = "export", identifier, "=", logical_expr_or
 program = { statement }
 ```

--- a/compiler/src/compiler.ml
+++ b/compiler/src/compiler.ml
@@ -82,7 +82,7 @@ let export stmt_ast =
 
 let function_body expr_ast =
   let max = ref (-1) in
-  let instructions = (Ir.instructions_of_ir (Ir.ir_of_ast expr_ast) max) @ [ 11 (* end *)] in
+  let instructions = (Ir.bin_of_instructions (Ir.instructions_of_ast expr_ast) max) @ [ 11 (* end *)] in
   let local_decl_count = !max + 1 in
   let decl =
     (if local_decl_count > 0

--- a/compiler/src/compiler.ml
+++ b/compiler/src/compiler.ml
@@ -58,6 +58,14 @@ let function_section ast =
     ] @
     List.init num_functions (fun _ -> 0 (* function 0 signature index *))
 
+let memory =
+  [ 5 (* section code *)
+  ; 3 (* section size *)
+  ; 1 (* num memories *)
+  ; 0 (* limits: flags *)
+  ; 1 (* limits: initial *)
+  ]
+
 let ( <.> ) f g x = f @@ g x
 
 let concatMap f = List.(concat <.> map f)
@@ -82,7 +90,7 @@ let export stmt_ast =
 
 let function_body expr_ast =
   let max = ref (-1) in
-  let instructions = (Ir.bin_of_instructions (Ir.instructions_of_ast expr_ast) max) @ [ 11 (* end *)] in
+  let instructions = (Ir.bin_of_insts (Ir.insts_of_expr_ast expr_ast) max) @ [ 11 (* end *)] in
   let local_decl_count = !max + 1 in
   let decl =
     (if local_decl_count > 0
@@ -116,6 +124,7 @@ let () =
           @ type_header
           @ type_0
           @ function_section ast
+          @ memory
           @ export ast
           @ code ast;
         close_out out

--- a/compiler/src/ir/ir.ml
+++ b/compiler/src/ir/ir.ml
@@ -49,6 +49,7 @@ let rec ir_of_ast = function
   | If (cond, t, e) ->
       ir_of_ast cond @ [I32Eqz; I32If (ir_of_ast e, ir_of_ast t)]
   | Let (_, _, _) -> failwith "Not implemented"
+  | Ident _ -> failwith "Not implemented"
 
 let instructions_of_ir irs max =
   let rec inner (irs, current, max) = match irs with

--- a/compiler/src/ir/ir.ml
+++ b/compiler/src/ir/ir.ml
@@ -48,6 +48,7 @@ let rec ir_of_ast = function
       ir_of_ast lhs @ [I32Local [TeeLocal 0; I32Eqz; I32If (ir_of_ast rhs, [GetLocal 0])]]
   | If (cond, t, e) ->
       ir_of_ast cond @ [I32Eqz; I32If (ir_of_ast e, ir_of_ast t)]
+  | Let (_, _, _) -> failwith "Not implemented"
 
 let instructions_of_ir irs max =
   let rec inner (irs, current, max) = match irs with

--- a/compiler/src/ir/ir.ml
+++ b/compiler/src/ir/ir.ml
@@ -1,6 +1,6 @@
 open Parser
 
-type ir =
+type instruction =
   | I32Const of int
   | I32Add
   | I32Sub
@@ -13,45 +13,45 @@ type ir =
   | I32Lt
   | I32Le
   | I32Eqz
-  | I32If of ir list * ir list
-  | I32Local of ir list
+  | I32If of instruction list * instruction list
+  | I32Local of instruction list
   | TeeLocal of int
   | GetLocal of int
 
-let rec ir_of_ast = function
+let rec instructions_of_ast = function
   | IntLiteral n -> [I32Const n]
   | Minus (expr) ->
-      ir_of_ast expr @ [I32Const (-1); I32Mul]
+      instructions_of_ast expr @ [I32Const (-1); I32Mul]
   | Add (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Add]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Add]
   | Sub (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Sub]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Sub]
   | Mul (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Mul]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Mul]
   | Div (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32DivS]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32DivS]
   | Eq (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Eq]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Eq]
   | Ne (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Ne]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Ne]
   | Greater (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Gt]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Gt]
   | GreaterE (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Ge]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Ge]
   | Less (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Lt]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Lt]
   | LessE (lhs, rhs) ->
-      ir_of_ast lhs @ ir_of_ast rhs @ [I32Le]
+      instructions_of_ast lhs @ instructions_of_ast rhs @ [I32Le]
   | And (lhs, rhs) ->
-      ir_of_ast lhs @ [I32Eqz; I32If ([I32Const 0], ir_of_ast rhs)]
+      instructions_of_ast lhs @ [I32Eqz; I32If ([I32Const 0], instructions_of_ast rhs)]
   | Or (lhs, rhs) ->
-      ir_of_ast lhs @ [I32Local [TeeLocal 0; I32Eqz; I32If (ir_of_ast rhs, [GetLocal 0])]]
+      instructions_of_ast lhs @ [I32Local [TeeLocal 0; I32Eqz; I32If (instructions_of_ast rhs, [GetLocal 0])]]
   | If (cond, t, e) ->
-      ir_of_ast cond @ [I32Eqz; I32If (ir_of_ast e, ir_of_ast t)]
+      instructions_of_ast cond @ [I32Eqz; I32If (instructions_of_ast e, instructions_of_ast t)]
   | Let (_, _, _) -> failwith "Not implemented"
   | Ident _ -> failwith "Not implemented"
 
-let instructions_of_ir irs max =
+let bin_of_instructions irs max =
   let rec inner (irs, current, max) = match irs with
     | [] -> []
     | I32Const n :: tail ->

--- a/compiler/src/ir/ir.mli
+++ b/compiler/src/ir/ir.mli
@@ -1,5 +1,5 @@
-type ir
+type instruction
 
-val ir_of_ast : Parser.expr_ast -> ir list
+val instructions_of_ast : Parser.expr_ast -> instruction list
 
-val instructions_of_ir : ir list -> int ref -> int list
+val bin_of_instructions : instruction list -> int ref -> int list

--- a/compiler/src/ir/ir.mli
+++ b/compiler/src/ir/ir.mli
@@ -1,5 +1,5 @@
 type instruction
 
-val instructions_of_ast : Parser.expr_ast -> instruction list
+val insts_of_expr_ast : Parser.expr_ast -> instruction list
 
-val bin_of_instructions : instruction list -> int ref -> int list
+val bin_of_insts : instruction list -> int ref -> int list

--- a/compiler/src/parser/parser.ml
+++ b/compiler/src/parser/parser.ml
@@ -121,8 +121,7 @@ let rec factor () =
           >> spaces
           >> logical_expr_or ()
           >>= (fun expr ->
-            spaces_opt
-            >> return @@ Let (ident, bound_expr, expr))))) src)
+            return @@ Let (ident, bound_expr, expr))))) src)
   in
     MParser (fun src ->
       parse (

--- a/compiler/src/parser/parser.ml
+++ b/compiler/src/parser/parser.ml
@@ -16,6 +16,7 @@ type expr_ast =
   | And of expr_ast * expr_ast
   | Or of expr_ast * expr_ast
   | If of expr_ast * expr_ast * expr_ast
+  | Let of string * expr_ast * expr_ast
   [@@deriving knights]
 
 type stmt_ast = ExportDef of string * expr_ast
@@ -75,6 +76,16 @@ let chain1 p op =
     >>= rest
     >>= (fun ast -> spaces_opt >> return ast)
 
+let letter = satisfy (fun c -> let code = Char.code c in (65 <= code && code <= 90) || (97 <= code && code <= 122))
+
+let digit = oneOf "0123456789"
+
+let rec string_of_chars = function
+  | [] -> ""
+  | c :: cs -> String.make 1 c ^ string_of_chars cs
+
+let identifier = (fun c cs -> string_of_chars (c :: cs)) <$> letter <*> (many (letter <|> digit))
+
 let rec factor () =
   let if_expr = MParser (fun src ->
     parse (
@@ -95,13 +106,30 @@ let rec factor () =
             spaces_opt
             >> return @@ If (ast, then_clause, else_clause))))) src)
   in
+  let let_expr = MParser (fun src ->
+    parse (
+      token "let"
+      >> spaces
+      >> identifier
+      >>= (fun ident ->
+        spaces_opt
+        >> char '='
+        >> spaces_opt
+        >> logical_expr_or ()
+        >>= (fun bound_expr ->
+          token "in"
+          >> spaces
+          >> logical_expr_or ()
+          >>= (fun expr ->
+            spaces_opt
+            >> return @@ Let (ident, bound_expr, expr))))) src)
+  in
     MParser (fun src ->
-      match parse integer src with
-        | []  ->
-            (match parse (char '(' >> (logical_expr_or () >>= (fun c -> char ')' >> return c))) src with
-              | [] -> parse if_expr src
-              | ast -> ast)
-        | ast -> ast)
+      parse (
+        integer
+        <|> (char '(' >> (logical_expr_or () >>= (fun c -> char ')' >> return c)))
+        <|> if_expr
+        <|> let_expr) src)
 
 and term () = chain1 (factor ()) mulop
 
@@ -112,16 +140,6 @@ and comparison_expr () = chain1 (arithmetic_expr ()) cmpop
 and logical_expr_and () = chain1 (comparison_expr ()) andop
 
 and logical_expr_or () = chain1 (logical_expr_and ()) orop
-
-let letter = satisfy (fun c -> let code = Char.code c in (65 <= code && code <= 90) || (97 <= code && code <= 122))
-
-let digit = oneOf "0123456789"
-
-let rec string_of_chars = function
-  | [] -> ""
-  | c :: cs -> String.make 1 c ^ string_of_chars cs
-
-let identifier = (fun c cs -> string_of_chars (c :: cs)) <$> letter <*> (many (letter <|> digit))
 
 let export_def =
   token "export"

--- a/compiler/src/parser/parser.ml
+++ b/compiler/src/parser/parser.ml
@@ -2,6 +2,7 @@ open Parser_combinator
 
 type expr_ast =
   | IntLiteral of int
+  | Ident of string
   | Minus of expr_ast
   | Add of expr_ast * expr_ast
   | Sub of expr_ast * expr_ast
@@ -128,7 +129,8 @@ let rec factor () =
         integer
         <|> (char '(' >> (logical_expr_or () >>= (fun c -> char ')' >> return c)))
         <|> if_expr
-        <|> let_expr) src)
+        <|> let_expr
+        <|> (identifier >>= (fun name -> return @@ Ident name))) src)
 
 and term () = chain1 (factor ()) mulop
 

--- a/compiler/src/parser/parser.mli
+++ b/compiler/src/parser/parser.mli
@@ -1,5 +1,6 @@
 type expr_ast =
   | IntLiteral of int
+  | Ident of string
   | Minus of expr_ast
   | Add of expr_ast * expr_ast
   | Sub of expr_ast * expr_ast

--- a/compiler/src/parser/parser.mli
+++ b/compiler/src/parser/parser.mli
@@ -14,6 +14,7 @@ type expr_ast =
   | And of expr_ast * expr_ast
   | Or of expr_ast * expr_ast
   | If of expr_ast * expr_ast * expr_ast
+  | Let of string * expr_ast * expr_ast
 
 type stmt_ast = ExportDef of string * expr_ast
 

--- a/compiler/test/let.psy
+++ b/compiler/test/let.psy
@@ -1,0 +1,7 @@
+export main =
+  let a = 3 in
+    let b = 4 in
+      a + b;
+
+export sub =
+  let foo = (let foo = 2 in foo + 1) in foo * 4


### PR DESCRIPTION
局所束縛を利用できるようにした

## コード例

`compiler/test/let.psy` :

```
export main =
  let a = 3 in
    let b = 4 in
      a + b;

export sub =
  let foo = (let foo = 2 in foo + 1) in foo * 4
```

```bash
$ psyche make compiler/test/let.psy
$ wasm2wat out.wasm
(module
  (type (;0;) (func (result i32)))
  (func (;0;) (type 0) (result i32)
    i32.const 0
    i32.const 3
    i32.store
    i32.const 4
    i32.const 4
    i32.store
    i32.const 0
    i32.load
    i32.const 4
    i32.load
    i32.add)
  (func (;1;) (type 0) (result i32)
    i32.const 0
    i32.const 4
    i32.const 2
    i32.store
    i32.const 4
    i32.load
    i32.const 1
    i32.add
    i32.store
    i32.const 0
    i32.load
    i32.const 4
    i32.mul)
  (memory (;0;) 1)
  (export "main" (func 0))
  (export "sub" (func 1)))
```