### PR TITLE
コメントを実装した

### DIFF
--- a/compiler/test/comments.psy
+++ b/compiler/test/comments.psy
@@ -1,0 +1,11 @@
+export main =
+  let a = 3 in
+    let b = 4 in
+      a + b;  (* コメント *)
+
+(*
+  複数行コメント
+*)
+
+export sub =  (* (* ネストすることも可能 *) *)
+  let foo = (let foo = 2 in foo + 1) in foo * 4


### PR DESCRIPTION
- `(*` 〜 `*)` の形式で記述する
- ``spaces``, ``spaces_opt`` パーサによるパース処理中に空白文字と同様に読み飛ばされる
- ネストに対応している

## コード例

```
export main =
  let a = 3 in
    let b = 4 in
      a + b;  (* コメント *)

(*
  複数行コメント
*)

export sub =  (* (* ネストすることも可能 *) *)
  let foo = (let foo = 2 in foo + 1) in foo * 4
```