### PR TITLE
テスト用スクリプトの実行可能ファイルの配置を修正

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -1,9 +1,10 @@
 build:
-	ocamlopt -o test test.ml
+	mkdir -p _build
+	ocamlopt -o _build/test test.ml
 	rm test.cmi test.cmx test.o
 
 test: build
-	./test
+	./_build/test
 
 clean:
 	rm -f test tmp result out.wasm


### PR DESCRIPTION
以前は `test-suite` ディレクトリ内に配置していたが，他の実行可能ファイルの配置にあわせて `test-suite/_build` ディレクトリ内に配置するように修正した